### PR TITLE
Delimit rev-spec in RunDumpToFile

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -1200,9 +1200,9 @@ bool RunDumpToFile(const FString& InPathToPlasticBinary, const FString& InRevSpe
 	FString Errors;
 
 	// start with the Plastic command itself, then add revspec and temp filename to dump
-	FString FullCommand = TEXT("cat ");
+	FString FullCommand = TEXT("cat \"");
 	FullCommand += InRevSpec;
-	FullCommand += TEXT(" --raw --file=\"");
+	FullCommand += TEXT("\" --raw --file=\"");
 	FullCommand += InDumpFileName;
 	FullCommand += TEXT("\"");
 


### PR DESCRIPTION
Adds quotation marks around the rev-spec in `RunDumpToFile` in order to fix History and other `cat`-using operations for repositories that have names that contain spaces.  Fixes #67.